### PR TITLE
Modal for creating workout sessions

### DIFF
--- a/backend/controllers/workoutSessionsController.js
+++ b/backend/controllers/workoutSessionsController.js
@@ -1,0 +1,63 @@
+import { prisma } from "../utils/helpers.js";
+
+const createWorkoutSession = async (req, res) => {
+  const { workoutTemplateId, date, duration, completionStatus, setRecords } =
+    req.body;
+  const userId = req.userId;
+
+  try {
+    if (!duration || !completionStatus || setRecords.length === 0) {
+      return res.status(400).json({
+        error:
+          "Invalid input. All fields are required and setRecords must not be empty.",
+      });
+    }
+
+    if (duration <= 0) {
+      return res.status(400).json({
+        error: "Duration must be greater than 0.",
+      });
+    }
+
+    if (!["COMPLETED", "PARTIAL"].includes(completionStatus)) {
+      return res.status(400).json({
+        error:
+          "Invalid completionStatus. Must be either 'COMPLETED' or 'PARTIAL'.",
+      });
+    }
+
+    const workoutSession = await prisma.workoutSession.create({
+      data: {
+        userId,
+        workoutTemplateId,
+        date: new Date(date),
+        duration,
+        completionStatus,
+        setRecords: {
+          create: setRecords.map((record) => ({
+            exerciseId: record.exerciseId,
+            reps: record.reps,
+            weight: record.weight,
+          })),
+        },
+      },
+      include: {
+        setRecords: {
+          include: {
+            exercise: true,
+          },
+        },
+        workoutTemplate: true,
+      },
+    });
+
+    res.status(201).json(workoutSession);
+  } catch (error) {
+    console.error("Error creating workout session:", error);
+    res.status(500).json({
+      error: "An error occurred while creating the workout session.",
+    });
+  }
+};
+
+export { createWorkoutSession };

--- a/backend/controllers/workoutTemplatesController.js
+++ b/backend/controllers/workoutTemplatesController.js
@@ -1,7 +1,7 @@
 import { prisma } from "../utils/helpers.js";
 
 const createWorkoutTemplate = async (req, res) => {
-  const { name, exercises } = req.body;
+  const { name, exercises, isPublic } = req.body;
   const userId = req.userId;
 
   try {
@@ -16,6 +16,7 @@ const createWorkoutTemplate = async (req, res) => {
       data: {
         name,
         userId,
+        isPublic,
         exercises: {
           create: await Promise.all(
             exercises.map(async (exercise) => ({

--- a/backend/routes/workoutSessionsRoutes.js
+++ b/backend/routes/workoutSessionsRoutes.js
@@ -1,0 +1,8 @@
+import { Router } from "express";
+import { createWorkoutSession } from "../controllers/workoutSessionsController.js";
+
+const router = Router();
+
+router.post("/", createWorkoutSession);
+
+export { router };

--- a/backend/server.js
+++ b/backend/server.js
@@ -4,6 +4,7 @@ import cors from "cors";
 import authRoutes from "./routes/authRoutes.js";
 import { authenticateToken } from "./middleware/authMiddleware.js";
 import { router as workoutTemplateRoutes } from "./routes/workoutTemplatesRoutes.js";
+import { router as workoutSessionRoutes } from "./routes/workoutSessionsRoutes.js";
 
 dotenv.config();
 const PORT = process.env.PORT || 3000;
@@ -18,6 +19,7 @@ app.use("", authenticateToken);
 
 // Protected Routes
 app.use("/workout-templates", workoutTemplateRoutes);
+app.use("/workout-sessions", workoutSessionRoutes);
 
 // START SERVER
 app.listen(PORT, () => {

--- a/frontend/src/components/CreateTemplateCard/CreateTemplateCard.tsx
+++ b/frontend/src/components/CreateTemplateCard/CreateTemplateCard.tsx
@@ -14,8 +14,8 @@ const CreateTemplateCard: React.FC<CreateTemplateCardProps> = ({
     setIsModalOpen(true);
   };
 
-  const closeModal = () => {
-    fetchTemplates();
+  const closeModal = (reloadTemplates = false) => {
+    if (reloadTemplates) fetchTemplates();
     setIsModalOpen(false);
   };
 

--- a/frontend/src/components/WorkoutSessionModal/WorkoutSessionModal.module.css
+++ b/frontend/src/components/WorkoutSessionModal/WorkoutSessionModal.module.css
@@ -1,0 +1,165 @@
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(3px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modalContent {
+  background-color: var(--primary);
+  padding: 2rem;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 600px;
+  max-height: 80vh;
+  overflow-y: auto;
+  color: #ffffff;
+}
+
+.modalTitle {
+  font-size: 1.8rem;
+  font-weight: 300;
+  margin-bottom: 1.5rem;
+  color: #ffffff;
+}
+
+.exerciseSection {
+  margin-bottom: 1.5rem;
+  padding: 1rem;
+  background-color: #383838;
+  border-radius: 6px;
+}
+
+.exerciseTitle {
+  font-size: 1.2rem;
+  margin-bottom: 1rem;
+  font-weight: 200;
+  color: #ffffff;
+}
+
+.setRow {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.templateOptions {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.completionStatusSection {
+  /* margin: 10px; */
+  position: relative;
+}
+
+.completionStatusLabel {
+  font-size: 18px;
+  margin-right: 20px;
+}
+
+.formField {
+  margin: 10px;
+  position: relative;
+}
+
+.formField input,
+.select {
+  padding: 20px 15px 10px 15px;
+  outline: none;
+  border: none;
+  border-radius: 5px;
+  background-color: var(--primary);
+  color: white;
+  font-size: 16px;
+  font-weight: 550;
+  transition: 0.3s ease-in-out;
+  box-shadow: 0 0 0 5px transparent;
+  box-shadow: 0 0 0 2px rgb(51, 51, 51, 0.5);
+}
+
+.formField input:hover,
+.formField input:focus {
+  box-shadow: 0 0 0 4px #333;
+}
+
+.formField span {
+  position: absolute;
+  left: 0;
+  top: 0;
+  padding: 13px 15px;
+  color: white;
+  font-size: 16px;
+  font-weight: 400;
+  transition: 0.3s ease-in-out;
+  pointer-events: none;
+}
+
+.formField input:focus + span,
+.formField input:valid + span {
+  transform: translateY(-12px) translateX(-5px) scale(0.95);
+  transition: 0.3s ease-in-out;
+}
+
+.removeButton,
+.addButton,
+.createButton,
+.cancelButton {
+  padding: 0.5rem 1.5rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: background-color 0.3s;
+}
+
+.removeButton {
+  background-color: #ff4444;
+  padding: 1rem 1.5rem;
+  color: white;
+}
+
+.addButton {
+  background-color: #4caf50;
+  color: white;
+  margin-top: 0.5rem;
+}
+
+.durationSection {
+  margin-top: 1.5rem;
+  display: flex;
+  align-items: center;
+}
+
+.buttonContainer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 20px;
+  margin-top: 1.5rem;
+}
+
+.createButton {
+  background-color: #4caf50;
+  color: white;
+  margin-left: 0.5rem;
+}
+
+.cancelButton {
+  background-color: #2c2c2c;
+  color: #ffffff;
+  border: 1px solid #505050;
+}
+
+.removeButton:hover,
+.addButton:hover,
+.createButton:hover,
+.cancelButton:hover {
+  opacity: 0.9;
+}

--- a/frontend/src/components/WorkoutSessionModal/WorkoutSessionModal.tsx
+++ b/frontend/src/components/WorkoutSessionModal/WorkoutSessionModal.tsx
@@ -11,16 +11,13 @@ const WorkoutSessionModal: React.FC<WorkoutSessionModalProps> = ({
   template,
 }) => {
   const [workoutSets, setWorkoutSets] = useState<Partial<SetRecord>[]>([]);
-  const [duration, setDuration] = useState<number | undefined>();
+  const [duration, setDuration] = useState<number>(0);
   const [completionStatus, setCompletionStatus] = useState<
     "COMPLETED" | "PARTIAL"
   >("COMPLETED");
 
   const addSetRecord = (exerciseId: number) => {
-    setWorkoutSets([
-      ...workoutSets,
-      { exerciseId, reps: undefined, weight: undefined },
-    ]);
+    setWorkoutSets([...workoutSets, { exerciseId, reps: 0, weight: 0 }]);
   };
 
   const updateSetRecord = (
@@ -93,7 +90,7 @@ const WorkoutSessionModal: React.FC<WorkoutSessionModalProps> = ({
                       <input
                         type="number"
                         required
-                        value={set.weight}
+                        value={set.weight !== 0 ? set.weight : ""}
                         onChange={(e) =>
                           updateSetRecord(
                             originalIndex,
@@ -109,7 +106,7 @@ const WorkoutSessionModal: React.FC<WorkoutSessionModalProps> = ({
                       <input
                         type="number"
                         required
-                        value={set.reps}
+                        value={set.reps !== 0 ? set.reps : ""}
                         onChange={(e) =>
                           updateSetRecord(
                             originalIndex,
@@ -146,7 +143,7 @@ const WorkoutSessionModal: React.FC<WorkoutSessionModalProps> = ({
                 id="duration"
                 type="number"
                 required
-                value={duration}
+                value={duration !== 0 ? duration : ""}
                 onChange={(e) => setDuration(Number(e.target.value))}
                 className={styles.input}
               />

--- a/frontend/src/components/WorkoutSessionModal/WorkoutSessionModal.tsx
+++ b/frontend/src/components/WorkoutSessionModal/WorkoutSessionModal.tsx
@@ -1,0 +1,189 @@
+import React, { useState } from "react";
+import styles from "./WorkoutSessionModal.module.css";
+
+interface WorkoutSessionModalProps {
+  onClose: () => void;
+  template: WorkoutTemplate;
+}
+
+const WorkoutSessionModal: React.FC<WorkoutSessionModalProps> = ({
+  onClose,
+  template,
+}) => {
+  const [workoutSets, setWorkoutSets] = useState<Partial<SetRecord>[]>([]);
+  const [duration, setDuration] = useState<number | undefined>();
+  const [completionStatus, setCompletionStatus] = useState<
+    "COMPLETED" | "PARTIAL"
+  >("COMPLETED");
+
+  const addSetRecord = (exerciseId: number) => {
+    setWorkoutSets([
+      ...workoutSets,
+      { exerciseId, reps: undefined, weight: undefined },
+    ]);
+  };
+
+  const updateSetRecord = (
+    index: number,
+    field: "reps" | "weight",
+    value: number
+  ) => {
+    const newWorkoutSets = [...workoutSets];
+    newWorkoutSets[index][field] = value;
+    setWorkoutSets(newWorkoutSets);
+  };
+
+  const removeWorkoutSet = (index: number) => {
+    setWorkoutSets(workoutSets.filter((_, i) => i !== index));
+  };
+
+  const handleCreateSession = async () => {
+    const newWorkoutSession: Partial<WorkoutSession> = {
+      workoutTemplateId: template.id,
+      date: new Date(),
+      duration: duration && duration * 60, // In seconds
+      completionStatus: completionStatus,
+      setRecords: workoutSets as SetRecord[],
+    };
+    console.log("Set Session", newWorkoutSession);
+
+    try {
+      const response = await fetch(
+        `${import.meta.env.VITE_BACKEND_URL}/workout-sessions`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${localStorage.getItem("token")}`,
+          },
+          body: JSON.stringify(newWorkoutSession),
+        }
+      );
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || "Failed to create workout session");
+      }
+
+      const createdSession = await response.json();
+      console.log("Created session:", createdSession);
+      onClose();
+    } catch (error) {
+      console.error("Error creating workout session:", error);
+    }
+  };
+
+  return (
+    <div className={styles.modalOverlay} onClick={onClose}>
+      <div className={styles.modalContent} onClick={(e) => e.stopPropagation()}>
+        <h2 className={styles.modalTitle}>{template.name} Session</h2>
+        {template.exercises.map((workoutTemplateExercise) => {
+          const exercise = workoutTemplateExercise.exercise;
+          return (
+            <div key={exercise.id} className={styles.exerciseSection}>
+              <h3 className={styles.exerciseTitle}>
+                {exercise.name.replaceAll("_", " ")}
+              </h3>
+              {workoutSets
+                .map((set, originalIndex) => ({ set, originalIndex }))
+                .filter(({ set }) => set.exerciseId === exercise.id)
+                .map(({ set, originalIndex }) => (
+                  <div key={originalIndex} className={styles.setRow}>
+                    <div className={styles.formField}>
+                      <input
+                        type="number"
+                        required
+                        value={set.weight}
+                        onChange={(e) =>
+                          updateSetRecord(
+                            originalIndex,
+                            "weight",
+                            Number(e.target.value)
+                          )
+                        }
+                        className={styles.input}
+                      />
+                      <span>Weight (lbs)</span>
+                    </div>
+                    <div className={styles.formField}>
+                      <input
+                        type="number"
+                        required
+                        value={set.reps}
+                        onChange={(e) =>
+                          updateSetRecord(
+                            originalIndex,
+                            "reps",
+                            Number(e.target.value)
+                          )
+                        }
+                        className={styles.input}
+                      />
+                      <span>Reps</span>
+                    </div>
+                    <button
+                      onClick={() => removeWorkoutSet(originalIndex)}
+                      className={styles.removeButton}
+                    >
+                      Remove
+                    </button>
+                  </div>
+                ))}
+
+              <button
+                onClick={() => addSetRecord(exercise.id)}
+                className={styles.addButton}
+              >
+                Add Set
+              </button>
+            </div>
+          );
+        })}
+        <div className={styles.templateOptions}>
+          <div className={styles.durationSection}>
+            <form className={styles.formField}>
+              <input
+                id="duration"
+                type="number"
+                required
+                value={duration}
+                onChange={(e) => setDuration(Number(e.target.value))}
+                className={styles.input}
+              />
+              <span>Duration (minutes)</span>
+            </form>
+          </div>
+          <div className={styles.completionStatusSection}>
+            <label
+              htmlFor="completionStatus"
+              className={styles.completionStatusLabel}
+            >
+              Status:
+            </label>
+            <select
+              id="completionStatus"
+              value={completionStatus}
+              onChange={(e) =>
+                setCompletionStatus(e.target.value as "COMPLETED" | "PARTIAL")
+              }
+              className={styles.select}
+            >
+              <option value="COMPLETED">Completed</option>
+              <option value="PARTIAL">Partial</option>
+            </select>
+          </div>
+        </div>
+        <div className={styles.buttonContainer}>
+          <button onClick={onClose} className={styles.cancelButton}>
+            Cancel
+          </button>
+          <button onClick={handleCreateSession} className={styles.createButton}>
+            Create Workout
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WorkoutSessionModal;

--- a/frontend/src/components/WorkoutTemplateModal/WorkoutTemplateModal.module.css
+++ b/frontend/src/components/WorkoutTemplateModal/WorkoutTemplateModal.module.css
@@ -39,6 +39,36 @@
   font-size: 1rem;
 }
 
+.radioSection {
+  display: flex;
+  margin-bottom: 20px;
+  gap: 50px;
+}
+
+.label {
+  font-weight: 400;
+}
+
+.optionsContainer {
+  display: flex;
+  gap: 25px;
+}
+
+.option {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.radioInput {
+  margin: 0;
+}
+
+.selectedValue {
+  font-size: 0.875rem;
+  color: #4b5563;
+}
+
 .searchContainer {
   position: relative;
   display: flex;

--- a/frontend/src/components/WorkoutTemplateModal/WorkoutTemplateModal.tsx
+++ b/frontend/src/components/WorkoutTemplateModal/WorkoutTemplateModal.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import styles from "./WorkoutTemplateModal.module.css";
 
 interface WorkoutTemplateModalProps {
-  closeModal: () => void;
+  closeModal: (reloadTemplates?: boolean) => void;
 }
 
 const WorkoutTemplateModal: React.FC<WorkoutTemplateModalProps> = ({
@@ -79,7 +79,7 @@ const WorkoutTemplateModal: React.FC<WorkoutTemplateModalProps> = ({
       );
 
       if (response.ok) {
-        closeModal();
+        closeModal(true);
       } else {
         throw new Error("Failed to create workout templateeee");
       }

--- a/frontend/src/components/WorkoutTemplateModal/WorkoutTemplateModal.tsx
+++ b/frontend/src/components/WorkoutTemplateModal/WorkoutTemplateModal.tsx
@@ -13,6 +13,7 @@ const WorkoutTemplateModal: React.FC<WorkoutTemplateModalProps> = ({
   const [exercises, setExercises] = useState<string[]>([]);
   const [selectedExercises, setSelectedExercises] = useState<string[]>([]);
   const [filteredExercises, setFilteredExercises] = useState<string[]>([]);
+  const [isPublic, setIsPublic] = useState<boolean>(true);
 
   useEffect(() => {
     const fetchExercises = async () => {
@@ -72,6 +73,7 @@ const WorkoutTemplateModal: React.FC<WorkoutTemplateModalProps> = ({
           body: JSON.stringify({
             name: workoutName,
             exercises: selectedExercises,
+            isPublic,
           }),
         }
       );
@@ -96,6 +98,11 @@ const WorkoutTemplateModal: React.FC<WorkoutTemplateModalProps> = ({
     closeModal();
   };
 
+  const handleOptionChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value === "true";
+    setIsPublic(value);
+  };
+
   return (
     <div className={styles.modalOverlay} onClick={handleCloseModal}>
       <div className={styles.modalContent} onClick={(e) => e.stopPropagation()}>
@@ -107,6 +114,31 @@ const WorkoutTemplateModal: React.FC<WorkoutTemplateModalProps> = ({
           placeholder="Workout template title"
           className={styles.input}
         />
+        <div className={styles.radioSection}>
+          <label className={styles.label}>Make template Public ?</label>
+          <div className={styles.optionsContainer}>
+            <label className={styles.option}>
+              <input
+                type="radio"
+                value="true"
+                checked={isPublic}
+                onChange={handleOptionChange}
+                className={styles.radioInput}
+              />
+              <span>Yes</span>
+            </label>
+            <label className={styles.option}>
+              <input
+                type="radio"
+                value="false"
+                checked={!isPublic}
+                onChange={handleOptionChange}
+                className={styles.radioInput}
+              />
+              <span>No</span>
+            </label>
+          </div>
+        </div>
         <div className={styles.searchContainer}>
           <input
             type="text"

--- a/frontend/src/screens/Dashboard/Dashboard.tsx
+++ b/frontend/src/screens/Dashboard/Dashboard.tsx
@@ -3,9 +3,19 @@ import styles from "../Dashboard/Dashboard.module.css";
 import WorkoutTemplateCard from "../../components/WorkoutTemplateCard/WorkoutTemplateCard";
 import Header from "../../components/Header/Header";
 import CreateTemplateCard from "../../components/CreateTemplateCard/CreateTemplateCard";
+import WorkoutSessionModal from "../../components/WorkoutSessionModal/WorkoutSessionModal";
 
 const Dashboard = () => {
   const [templateList, setTemplateList] = useState<WorkoutTemplate[]>([]);
+
+  const [isWorkoutSessionOpen, setIsWorkoutSessionOpen] = useState(false);
+  const [selectedTemplate, setSelectedTemplate] =
+    useState<WorkoutTemplate | null>(null);
+
+  const handleTemplateClick = (template: WorkoutTemplate) => {
+    setSelectedTemplate(template);
+    setIsWorkoutSessionOpen(true);
+  };
 
   const fetchTemplates = async () => {
     try {
@@ -25,7 +35,7 @@ const Dashboard = () => {
       const data = await response.json();
       setTemplateList(data);
     } catch (err: any) {
-      alert(err.message);
+      console.error(err.message);
     }
   };
 
@@ -35,12 +45,23 @@ const Dashboard = () => {
 
   return (
     <div className={styles.dashboardContainer}>
+      {selectedTemplate && isWorkoutSessionOpen ? (
+        <WorkoutSessionModal
+          onClose={() => setIsWorkoutSessionOpen(false)}
+          template={selectedTemplate}
+        />
+      ) : <></>}
       <Header />
       <div className={styles.dashboardContent}>
         <p className={styles.pageTitle}>Dashboard</p>
         <div className={styles.templateList}>
           {templateList.map((template, index) => (
-            <div key={index}>
+            <div
+              key={index}
+              onClick={() => {
+                handleTemplateClick(template);
+              }}
+            >
               <WorkoutTemplateCard template={template} />
             </div>
           ))}


### PR DESCRIPTION
## Description
In this pull request I created the modal which allows users to create and manage workout sessions based on a given template. It provides functionality to add, update, and remove sets of exercises, and upon completion, sends the session data to my backend server to be stored. In the backend, I created a file to be my controller for my workoutSessions operations, in this case, it receives data from the request and first validates all the information from the frontend. After this, I create a workout session object. You will notice that I have a mapping over setRecords ( later changed to workoutSets ). This is to first create each set before creating the workout session that has all the sets.
<what this pull request is doing>
<what will be done in later PRs and not included here>

## Test Plan

https://github.com/bryanansong/ZenFitness/assets/50881304/bcc9c4a3-07f2-4f26-8da4-60cb7b0f4a9a


<insert images or gifs of feature>
<otherwise, say how code was tested if not UI facing>
<any edge cases you might have specifically tested>
