### PR TITLE
Add time decay

### DIFF
--- a/backend/controllers/recommendationController.js
+++ b/backend/controllers/recommendationController.js
@@ -1,15 +1,18 @@
 import { prisma } from "../utils/helpers.js";
 import { calculateNetVotes } from "./templateStatisticsController.js";
 import { getPublicTemplates } from "./workoutTemplatesController.js";
+import { getUserExerciseHistory } from "./userStatistics.js"; // Assume this function exists
 
 /*
 1. Calculate the base score for each template.
 2. Apply the time decay function to account for recency.
 3. Incorporate personalization factors to tailor the recommendations.
 4. Sort the templates based on their final scores and return top results.
+TODO: Set the userId from the http request
 */
 
 const templates = await getPublicTemplates();
+let userId = 1; // TODO: Replace this with the userId from the req attributes in the http request
 
 const fullDayInms = 24 * 60 * 60 * 1000;
 
@@ -75,5 +78,5 @@ const calculateBaseScore = (template, maxValues) => {
 const calculateTimeDecay = (createdAt) => {
   const templateAgeInDays =
     (Date.now() - new Date(createdAt).getTime()) / fullDayInms;
-  return 1 / (1 + Math.log(1 + templateAgeInDays));
+  return 1 / (1 + Math.log(1 + templateAgeInDays) * 0.2);
 };

--- a/backend/controllers/recommendationController.js
+++ b/backend/controllers/recommendationController.js
@@ -1,7 +1,7 @@
 import { prisma } from "../utils/helpers.js";
 import { calculateNetVotes } from "./templateStatisticsController.js";
 import { getPublicTemplates } from "./workoutTemplatesController.js";
-import { getUserExerciseHistory } from "./userStatistics.js"; // Assume this function exists
+import { getUserExerciseHistory } from "./userStatistics.js";
 
 const fullDayInms = 24 * 60 * 60 * 1000;
 

--- a/backend/controllers/recommendationController.js
+++ b/backend/controllers/recommendationController.js
@@ -11,7 +11,7 @@ import { getPublicTemplates } from "./workoutTemplatesController.js";
 
 const templates = await getPublicTemplates();
 
-const fullDayInHours = 24 * 60 * 60 * 1000;
+const fullDayInms = 24 * 60 * 60 * 1000;
 
 const weights = {
   copyCount: 0.6,
@@ -65,9 +65,15 @@ const calculateBaseScore = (template, maxValues) => {
 
   // Boost for new templates
   const newTemplateBoost = 0.1;
-  if (template.createdAt > new Date(Date.now() - fullDayInHours)) {
+  if (template.createdAt > new Date(Date.now() - fullDayInms)) {
     score += newTemplateBoost;
   }
 
   return Math.min(score, 1);
+};
+
+const calculateTimeDecay = (createdAt) => {
+  const templateAgeInDays =
+    (Date.now() - new Date(createdAt).getTime()) / fullDayInms;
+  return 1 / (1 + Math.log(1 + templateAgeInDays));
 };

--- a/backend/controllers/userStatistics.js
+++ b/backend/controllers/userStatistics.js
@@ -86,4 +86,34 @@ const calculateStreak = (workoutSessions) => {
   return streak;
 };
 
-export { getUserStatistics };
+const getUserExerciseHistory = async (userId) => {
+  try {
+    const userSessions = await prisma.workoutSession.findMany({
+      where: {
+        userId: userId,
+      },
+      include: {
+        workoutSets: {
+          include: {
+            exercise: true,
+          },
+        },
+      },
+    });
+
+    // Extract unique exercise IDs from all workout sessions
+    const exerciseIds = new Set();
+    userSessions.forEach((session) => {
+      session.workoutSets.forEach((set) => {
+        exerciseIds.add(set.exercise.id);
+      });
+    });
+
+    return Array.from(exerciseIds);
+  } catch (error) {
+    console.error("Error fetching user exercise history:", error);
+    throw error;
+  }
+};
+
+export { getUserStatistics, getUserExerciseHistory };

--- a/backend/routes/workoutTemplatesRoutes.js
+++ b/backend/routes/workoutTemplatesRoutes.js
@@ -1,12 +1,12 @@
 import { Router } from "express";
 import {
   createWorkoutTemplate,
-  getFeed,
   getWorkoutTemplateInfo,
   getWorkoutTemplates,
   vote,
   copyWorkoutTemplate,
 } from "../controllers/workoutTemplatesController.js";
+import { getRecommendations } from "../controllers/recommendationController.js";
 
 const router = Router();
 
@@ -14,7 +14,7 @@ router.post("/:templateId/vote", vote);
 router.post("/:templateId/copy", copyWorkoutTemplate);
 router.post("/", createWorkoutTemplate);
 
-router.get("/feed", getFeed);
+router.get("/feed", getRecommendations);
 router.get("/:templateId", getWorkoutTemplateInfo);
 router.get("/", getWorkoutTemplates);
 


### PR DESCRIPTION
## Description
I added a function to calculate the time decay of a post based on the time it was created. The formula I used to do this is:
`1 / (1 + Math.log(1 + templateAgeInDays) * 0.2)`. Here is an image showing what the the decay looks like with respect to the number of days ago it was created ( specifically the green line ): 
![image](https://github.com/user-attachments/assets/43b09410-c2df-4abe-b05d-fade3fa5fe39)

I also created the function for calculating the personalization factor which basically boosts the score of a workout template if a user follows the author of a template and if the exercises contained in the workout template are similar to what the user has done before.

After all that, I created the route to allow the frontend to fetch the ranked workout template.

For more information on why I need a base score check out this document on my algorithm plan: [Recommendation Algorithm](https://docs.google.com/document/d/1TH2X7wh-HUKsl_SfB3tdCpVTyRJAY__sXK-T8Ih1jrk/edit?usp=sharing)

## Test Plan
Here is an image of the score calculated on each public workout template
<img width="640" alt="Screenshot 2024-07-13 at 2 43 40 PM" src="https://github.com/user-attachments/assets/cab5525a-b62e-4e32-b3d6-b876b2e4b337">
Here is what is displayed on the frontend based on the calculated score
<img width="1728" alt="Screenshot 2024-07-13 at 2 44 39 PM" src="https://github.com/user-attachments/assets/2bfa7508-04a6-41e6-b6c4-a7718d822b6e">